### PR TITLE
Add chip types management

### DIFF
--- a/cobro.js
+++ b/cobro.js
@@ -20,6 +20,9 @@ document.addEventListener("DOMContentLoaded", () => {
   // NUEVA variable global con todos los clientes para filtrar
   let currentClients = {};
 
+  // Tipos de fichas configurados
+  let chipTypes = {};
+
   // Forzar cierre de sesión para desarrollo
   auth.signOut();
 
@@ -86,10 +89,27 @@ document.addEventListener("DOMContentLoaded", () => {
     alert("Precios actualizados");
   });
 
+  // Agregar tipo de ficha
+  document.getElementById("add-chip-type-btn")?.addEventListener("click", () => {
+    const name = document.getElementById("chip-name").value.trim();
+    const value = parseFloat(document.getElementById("chip-value").value) || 0;
+    if (!name) return alert("Ingresa nombre de ficha");
+    chipTypesRef.child(name).set({ value });
+    document.getElementById("chip-name").value = "";
+    document.getElementById("chip-value").value = "";
+  });
+
   /* =====================
        CLIENTES
   ===================== */
   const clientsRef = database.ref("clients");
+  const chipTypesRef = database.ref("chipTypes");
+
+  chipTypesRef.on("value", snapshot => {
+    chipTypes = snapshot.val() || {};
+    renderChipTypes();
+    renderClients(currentClients);
+  });
 
   clientsRef.on("value", snapshot => {
     currentClients = snapshot.val() || {};
@@ -101,6 +121,7 @@ document.addEventListener("DOMContentLoaded", () => {
     clientsRef.push({
       name,
       beerCounts: { Entrada: 0, Recompra: 0, Adicion: 0 },
+      chips: {},
       createdAt: firebase.database.ServerValue.TIMESTAMP
     });
   }
@@ -124,6 +145,11 @@ document.addEventListener("DOMContentLoaded", () => {
   function toggleBeerCount(clientKey, beerType) {
     const ref = database.ref(`clients/${clientKey}/beerCounts/${beerType}`);
     ref.transaction(val => (val === 1 ? 0 : 1));
+  }
+
+  function updateChipCount(clientKey, chipType, increment) {
+    const ref = database.ref(`clients/${clientKey}/chips/${chipType}`);
+    ref.transaction(count => Math.max(0, (count || 0) + increment));
   }
 
   function deleteClient(clientKey) {
@@ -228,6 +254,36 @@ incBtn.addEventListener("click", e => {
         countsDiv.appendChild(wrapper);
       });
 
+      // Mostrar fichas asignadas
+      Object.keys(chipTypes).forEach(type => {
+        const wrapper = document.createElement("div");
+        wrapper.className = "client-card-count";
+        wrapper.innerHTML = `<span>${type}</span>`;
+
+        const count = (client.chips && client.chips[type]) || 0;
+        const val = document.createElement("span");
+        val.className = "count-value";
+        val.textContent = count;
+        wrapper.appendChild(val);
+
+        const controls = document.createElement("div");
+        controls.className = "count-controls";
+        controls.innerHTML = `
+          <button class="action-btn arrow-btn">&lt;</button>
+          <button class="action-btn arrow-btn">&gt;</button>`;
+        const [decBtn, incBtn] = controls.querySelectorAll("button");
+        decBtn.addEventListener("click", e => {
+          e.stopPropagation();
+          updateChipCount(key, type, -1);
+        });
+        incBtn.addEventListener("click", e => {
+          e.stopPropagation();
+          updateChipCount(key, type, 1);
+        });
+        wrapper.appendChild(controls);
+        countsDiv.appendChild(wrapper);
+      });
+
       card.appendChild(countsDiv);
 
       /* ---- TOTAL ---- */
@@ -278,6 +334,18 @@ incBtn.addEventListener("click", e => {
     document.getElementById("total-adiciones").textContent = `Total de Adiciones: ${adiciones}`;
     document.getElementById("total-fichas").textContent    = `Total de Fichas: ${totalFichas.toLocaleString()}`;
     document.getElementById("stack-promedio").textContent  = `Stack Promedio: ${stackProm.toLocaleString()}`;
+  }
+
+  function renderChipTypes() {
+    const list = document.getElementById("chip-types-list");
+    if (!list) return;
+    list.innerHTML = "";
+    Object.entries(chipTypes).forEach(([name, cfg]) => {
+      const div = document.createElement("div");
+      div.className = "chip-type-item";
+      div.textContent = `${name}: $${(cfg.value || 0)}`;
+      list.appendChild(div);
+    });
   }
 
 
@@ -641,6 +709,7 @@ incBtn.addEventListener("click", e => {
     });
   }
   updatePricesUI();
+  renderChipTypes();
 });
 
 const fullscreenToggleBtn = document.getElementById("toggle-fullscreen-btn");

--- a/index.html
+++ b/index.html
@@ -121,6 +121,17 @@
           <p id="total-fichas">Total de Fichas: 0</p>
           <p id="stack-promedio">Stack Promedio: 0</p>
         </div>
+
+        <!-- Configuración de tipos de fichas -->
+        <section class="chip-types-section">
+          <h3>Tipos de Ficha</h3>
+          <div id="chip-types-list" class="chip-types-list"></div>
+          <div class="chip-add">
+            <input id="chip-name" type="text" placeholder="Color o nombre">
+            <input id="chip-value" type="number" placeholder="Valor">
+            <button id="add-chip-type-btn" class="btn">Agregar Ficha</button>
+          </div>
+        </section>
       </section>
 
       <!-- Sección de Premios -->

--- a/styles2.css
+++ b/styles2.css
@@ -446,6 +446,32 @@ footer {
 }
 
 /* =====================
+   TIPOS DE FICHAS
+======================= */
+.chip-types-section {
+  margin-top: 20px;
+}
+.chip-types-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.chip-type-item {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 6px 12px;
+  border-radius: 8px;
+}
+.chip-add input {
+  margin: 5px;
+  padding: 6px;
+  border-radius: 4px;
+  border: none;
+  text-align: center;
+}
+
+/* =====================
    SECCIÓN DE PREMIOS
 ======================= */
 .premios-section {


### PR DESCRIPTION
## Summary
- allow adding chip types with name and value
- list configured chip types
- assign chip counts per player via UI
- style chip type manager

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840e78045488325a8b5f1c37d396bad